### PR TITLE
Add multiarch build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,9 +254,10 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build local-kms image
+          name: Build local-kms images
           command: |
-            docker build -t local-kms .
+            docker buildx build --load --platform linux/amd64 -t local-kms:amd64 .
+            docker buildx build --load --platform linux/arm64 -t local-kms:arm64 .
       - run:
           name: Build testing image
           command: |
@@ -264,16 +265,18 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            docker run -d --name local-kms local-kms
+            docker run -d --name local-kms local-kms:amd64
             docker run -e KMS_URL="http://localhost:8080" --network container:local-kms testing pytest
       - run:
-          name: Save local-kms image
+          name: Save local-kms images
           command: |
-            docker save -o /tmp/local-kms.tar local-kms
+            docker save -o /tmp/local-kms-amd64.tar local-kms:amd64
+            docker save -o /tmp/local-kms-arm64.tar local-kms:arm64
       - persist_to_workspace:
           root: /tmp
           paths:
-            - local-kms.tar
+            - local-kms-amd64.tar
+            - local-kms-arm64.tar
 
   build-docker-push-latest:
     docker:
@@ -283,9 +286,10 @@ jobs:
           at: ~/image
       - setup_remote_docker
       - run:
-          name: Load local-kms image
+          name: Load local-kms images
           command: |
-            docker load -i ~/image/local-kms.tar
+            docker load -i ~/image/local-kms-amd64.tar
+            docker load -i ~/image/local-kms-arm64.tar
             docker images
       - run:
           name: Login to Docker Hub
@@ -294,8 +298,16 @@ jobs:
       - run:
           name: Push to Docker Hub
           command: |
-            docker tag local-kms:latest nsmithuk/local-kms:latest
-            docker push nsmithuk/local-kms:latest
+            docker tag local-kms:amd64 nsmithuk/local-kms:amd64
+            docker tag local-kms:arm64 nsmithuk/local-kms:arm64
+
+            docker push nsmithuk/local-kms:amd64
+            docker push nsmithuk/local-kms:arm64
+
+            docker manifest create nsmithuk/local-kms:latest --amend nsmithuk/local-kms:amd64
+            docker manifest create nsmithuk/local-kms:latest --amend nsmithuk/local-kms:arm64
+
+            docker manifest push nsmithuk/local-kms:latest
 
   build-docker-push-tag:
     docker:
@@ -307,7 +319,8 @@ jobs:
       - run:
           name: Load local-kms image
           command: |
-            docker load -i ~/image/local-kms.tar
+            docker load -i ~/image/local-kms-amd64.tar
+            docker load -i ~/image/local-kms-arm64.tar
             docker images
       - run:
           name: Login to Docker Hub
@@ -320,9 +333,20 @@ jobs:
             echo "Version Full << pipeline.git.tag >>"
             echo "Version Major $VERSION_MAJOR"
 
-            docker tag local-kms:latest nsmithuk/local-kms:${VERSION_MAJOR}
-            docker tag local-kms:latest nsmithuk/local-kms:<< pipeline.git.tag >>
-            docker push --all-tags nsmithuk/local-kms
+            docker tag local-kms:amd64 nsmithuk/local-kms:amd64
+            docker tag local-kms:arm64 nsmithuk/local-kms:arm64
+
+            docker push nsmithuk/local-kms:amd64
+            docker push nsmithuk/local-kms:arm64
+
+            docker manifest create nsmithuk/local-kms:${VERSION_MAJOR} --amend nsmithuk/local-kms:amd64
+            docker manifest create nsmithuk/local-kms:${VERSION_MAJOR} --amend nsmithuk/local-kms:arm64
+
+            docker manifest create nsmithuk/local-kms:<< pipeline.git.tag >> --amend nsmithuk/local-kms:amd64
+            docker manifest create nsmithuk/local-kms:<< pipeline.git.tag >> --amend nsmithuk/local-kms:arm64
+
+            docker manifest push nsmithuk/local-kms:${VERSION_MAJOR}
+            docker manifest push nsmithuk/local-kms:<< pipeline.git.tag >>
 
   release-artifacts-s3:
     executor: aws-cli/default


### PR DESCRIPTION
Here's a shot at getting multiarch images pushed to docker hub.

With these changes, a `linux/amd64` and a `linux/arm64` image will be built and the following tags pushed:
- `amd64` and `arm64`
- `latest`, `${VERSION_MAJOR}`, `<< pipeline.git.tag >>` (manifest with both images)

Unfortunately I was not able to test it because I couldn't set up Circle CI (keeps throwing errors when I try to connect the project).

Resolves https://github.com/nsmithuk/local-kms/issues/37.