### PR TITLE
Replace vulnerable satori/go.uuid with gofrs/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.42.19
 	github.com/btcsuite/btcd v0.22.0-beta
-	github.com/satori/go.uuid v1.2.0
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/sirupsen/logrus v1.4.2
 	github.com/syndtr/goleveldb v1.0.0
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
@@ -46,8 +48,6 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/src/handler/create_key.go
+++ b/src/handler/create_key.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/gofrs/uuid"
 	"github.com/nsmithuk/local-kms/src/cmk"
 	"github.com/nsmithuk/local-kms/src/config"
 	"github.com/nsmithuk/local-kms/src/data"
-	uuid "github.com/satori/go.uuid"
 )
 
 func (r *RequestHandler) CreateKey() Response {
@@ -22,7 +22,7 @@ func (r *RequestHandler) CreateKey() Response {
 
 	//---
 
-	keyId := uuid.NewV4().String()
+	keyId := uuid.Must(uuid.NewV4()).String()
 
 	metadata := cmk.KeyMetadata{
 		Arn:          config.ArnPrefix() + "key/" + keyId,


### PR DESCRIPTION
The satori/go.uuid library has a known vulnerability described in
[CVE-2021-3538](https://www.cvedetails.com/cve/CVE-2021-3538/),

> A flaw was found in github.com/satori/go.uuid in versions from commit
> 0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c to
> d91630c8510268e75203009fe7daf2b8e1d60c45. Due to insecure randomness in the
> g.rand.Read function the generated UUIDs are predictable for an attacker.

and [gofrs/uuid](https://github.com/gofrs/uuid#project-history) is a fork of
satori that was created to fix the vulnerabilities, as the original project
is no longer maintained.

A detail to take into account is that the gofrs forces error handling when UUID
creation fails, which only happens for v4 UUIDs when a random number couldn't be
obtained from the source. This should be a very low percentage and in practice
shouldn't happen (even less for this project as it is something you run locally
or in tests), but nevertheless the error *should* be handled.

As with satori this problem still existed, but it panicked when it failed, to
maintain the behaviour uuid.Must is used, which panics when an error occurs.

Satori panic reference: [[1]](https://github.com/satori/go.uuid/blob/v1.2.0/generator.go#L153) [[2]](https://github.com/satori/go.uuid/blob/f58768cc1a7a7e77a3bd49e98cdd21419399b6a3/generator.go#L199)