### PR TITLE
Add KeySpec output when getting pubkey

### DIFF
--- a/src/handler/get_public_key.go
+++ b/src/handler/get_public_key.go
@@ -67,6 +67,7 @@ func (r *RequestHandler) GetPublicKey() Response {
 	return NewResponse(200, &struct {
 		KeyId                 string
 		CustomerMasterKeySpec cmk.KeySpec
+		KeySpec               cmk.KeySpec
 		//EncryptionAlgorithms	[]cmk.EncryptionAlgorithm
 		SigningAlgorithms []cmk.SigningAlgorithm
 		KeyUsage          cmk.KeyUsage
@@ -74,6 +75,7 @@ func (r *RequestHandler) GetPublicKey() Response {
 	}{
 		KeyId:                 key.GetArn(),
 		CustomerMasterKeySpec: key.GetMetadata().CustomerMasterKeySpec,
+		KeySpec:               key.GetMetadata().KeySpec,
 		//EncryptionAlgorithms: key.GetMetadata().EncryptionAlgorithms,
 		SigningAlgorithms: key.GetMetadata().SigningAlgorithms,
 		KeyUsage:          key.GetMetadata().KeyUsage,


### PR DESCRIPTION
Added `KeySpec` field when getting public key :)

As you know, `CustomerMasterKeySpec` field has been deprecated at https://github.com/aws/aws-sdk-go-v2/blob/main/service/kms/api_op_GetPublicKey.go#L120