### PR TITLE
Implement missing KMS operations and policy/alias/tag handling

### DIFF
--- a/internal/kms/cancel_key_deletion.go
+++ b/internal/kms/cancel_key_deletion.go
@@ -2,11 +2,46 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) CancelKeyDeletion(ctx context.Context, req awskms.CancelKeyDeletionInput) (*awskms.CancelKeyDeletionOutput, []error) {
-	// TODO
-	return nil, nil
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if !key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is not pending deletion.", key.GetArn()),
+		}
+	}
+
+	key.GetMetadata().DeletionDate = nil
+	key.GetMetadata().PendingDeletionWindowInDays = nil
+	key.GetMetadata().Enabled = false
+	key.GetMetadata().KeyState = types.KeyStateDisabled
+
+	if err := k.Db.SaveKey(key); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.CancelKeyDeletionOutput{
+		KeyId: key.GetMetadata().Arn,
+	}, nil
 }

--- a/internal/kms/disable_key.go
+++ b/internal/kms/disable_key.go
@@ -2,11 +2,42 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
-func (k KmsService) DisableKey(ctx context.Context, req awskms.CancelKeyDeletionInput) (*awskms.CancelKeyDeletionOutput, []error) {
-	// TODO
-	return nil, nil
+func (k KmsService) DisableKey(ctx context.Context, req awskms.DisableKeyInput) (*awskms.DisableKeyOutput, []error) {
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	key.GetMetadata().Enabled = false
+	key.GetMetadata().KeyState = types.KeyStateDisabled
+
+	if err := k.Db.SaveKey(key); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.DisableKeyOutput{}, nil
 }

--- a/internal/kms/disable_key_rotation.go
+++ b/internal/kms/disable_key_rotation.go
@@ -2,11 +2,39 @@ package kms
 
 import (
 	"context"
+	"time"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/cmk"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) DisableKeyRotation(ctx context.Context, req awskms.DisableKeyRotationInput) (*awskms.DisableKeyRotationOutput, []error) {
-	// TODO
-	return nil, nil
+	key, err := k.getUsableKey(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	if key.GetMetadata().Origin == types.OriginTypeExternal {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is not supported for imported key material"),
+		}
+	}
+
+	symmetricKey, ok := key.(*cmk.SymmetricKey)
+	if !ok {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is supported only for symmetric keys"),
+		}
+	}
+
+	symmetricKey.RotationPeriodInDays = 0
+	symmetricKey.NextKeyRotation = time.Time{}
+
+	if err := k.Db.SaveKey(symmetricKey); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.DisableKeyRotationOutput{}, nil
 }

--- a/internal/kms/enable_key.go
+++ b/internal/kms/enable_key.go
@@ -2,11 +2,42 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) EnableKey(ctx context.Context, req awskms.EnableKeyInput) (*awskms.EnableKeyOutput, []error) {
-	// TODO
-	return nil, nil
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	key.GetMetadata().Enabled = true
+	key.GetMetadata().KeyState = types.KeyStateEnabled
+
+	if err := k.Db.SaveKey(key); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.EnableKeyOutput{}, nil
 }

--- a/internal/kms/enable_key_rotation.go
+++ b/internal/kms/enable_key_rotation.go
@@ -2,11 +2,49 @@ package kms
 
 import (
 	"context"
+	"time"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/cmk"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) EnableKeyRotation(ctx context.Context, req awskms.EnableKeyRotationInput) (*awskms.EnableKeyRotationOutput, []error) {
-	// TODO
-	return nil, nil
+	key, err := k.getUsableKey(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	if key.GetMetadata().Origin == types.OriginTypeExternal {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is not supported for imported key material"),
+		}
+	}
+
+	symmetricKey, ok := key.(*cmk.SymmetricKey)
+	if !ok {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is supported only for symmetric keys"),
+		}
+	}
+
+	rotationPeriodInDays := int32(365)
+	if req.RotationPeriodInDays != nil {
+		if *req.RotationPeriodInDays < 1 {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseValidationError, "RotationPeriodInDays must be greater than 0"),
+			}
+		}
+		rotationPeriodInDays = *req.RotationPeriodInDays
+	}
+
+	symmetricKey.RotationPeriodInDays = rotationPeriodInDays
+	symmetricKey.NextKeyRotation = time.Now().AddDate(0, 0, int(rotationPeriodInDays))
+
+	if err := k.Db.SaveKey(symmetricKey); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.EnableKeyRotationOutput{}, nil
 }

--- a/internal/kms/get_key_policy.go
+++ b/internal/kms/get_key_policy.go
@@ -2,11 +2,46 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) GetKeyPolicy(ctx context.Context, req awskms.GetKeyPolicyInput) (*awskms.GetKeyPolicyOutput, []error) {
-	// TODO
-	return nil, nil
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	policyName := "default"
+	if req.PolicyName != nil && *req.PolicyName != "" {
+		policyName = *req.PolicyName
+	}
+	if policyName != "default" {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseValidationError, "PolicyName must be default"),
+		}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	policy, err := getKeyPolicy(key)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.GetKeyPolicyOutput{
+		Policy:     &policy,
+		PolicyName: &policyName,
+	}, nil
 }

--- a/internal/kms/get_key_rotation_status.go
+++ b/internal/kms/get_key_rotation_status.go
@@ -2,11 +2,52 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/cmk"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) GetKeyRotationStatus(ctx context.Context, req awskms.GetKeyRotationStatusInput) (*awskms.GetKeyRotationStatusOutput, []error) {
-	// TODO
-	return nil, nil
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.GetMetadata().KeySpec != types.KeySpecSymmetricDefault {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is supported only for symmetric keys"),
+		}
+	}
+
+	symmetricKey, ok := key.(*cmk.SymmetricKey)
+	if !ok {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseUnsupportedOperationException, "automatic rotation is supported only for symmetric keys"),
+		}
+	}
+
+	keyRotationEnabled := symmetricKey.RotationPeriodInDays > 0
+	var rotationPeriod *int32
+	if keyRotationEnabled {
+		rotationPeriod = &symmetricKey.RotationPeriodInDays
+	}
+
+	return &awskms.GetKeyRotationStatusOutput{
+		KeyRotationEnabled:   keyRotationEnabled,
+		RotationPeriodInDays: rotationPeriod,
+	}, nil
 }

--- a/internal/kms/helpers.go
+++ b/internal/kms/helpers.go
@@ -1,6 +1,11 @@
 package kms
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/nsmithuk/local-kms/internal/kms/cmk"
+)
 
 func EncodeMarker(in string) *string {
 	nextMarkerB64 := base64.StdEncoding.EncodeToString([]byte(in))
@@ -14,4 +19,52 @@ func DecodeMarker(in *string) (*string, error) {
 	}
 	nextMarketStr := string(data)
 	return &nextMarketStr, nil
+}
+
+func getKeyPolicy(key cmk.Key) (string, error) {
+	if key == nil {
+		return "", fmt.Errorf("key is nil")
+	}
+
+	switch typedKey := key.(type) {
+	case *cmk.SymmetricKey:
+		return typedKey.Policy, nil
+	case *cmk.RsaKey:
+		return typedKey.Policy, nil
+	case *cmk.EcdsaKey:
+		return typedKey.Policy, nil
+	case *cmk.Ed25519Key:
+		return typedKey.Policy, nil
+	case *cmk.HmacKey:
+		return typedKey.Policy, nil
+	case *cmk.MlDsaKey:
+		return typedKey.Policy, nil
+	default:
+		return "", fmt.Errorf("unsupported key type for policy")
+	}
+}
+
+func setKeyPolicy(key cmk.Key, policy string) error {
+	if key == nil {
+		return fmt.Errorf("key is nil")
+	}
+
+	switch typedKey := key.(type) {
+	case *cmk.SymmetricKey:
+		typedKey.Policy = policy
+	case *cmk.RsaKey:
+		typedKey.Policy = policy
+	case *cmk.EcdsaKey:
+		typedKey.Policy = policy
+	case *cmk.Ed25519Key:
+		typedKey.Policy = policy
+	case *cmk.HmacKey:
+		typedKey.Policy = policy
+	case *cmk.MlDsaKey:
+		typedKey.Policy = policy
+	default:
+		return fmt.Errorf("unsupported key type for policy")
+	}
+
+	return nil
 }

--- a/internal/kms/list_aliases.go
+++ b/internal/kms/list_aliases.go
@@ -2,11 +2,85 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) ListAliases(ctx context.Context, req awskms.ListAliasesInput) (*awskms.ListAliasesOutput, []error) {
-	// TODO
-	return nil, nil
+	limit := int32(50)
+	if req.Limit != nil {
+		limit = *req.Limit
+
+		if limit < 1 || limit > 100 {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseValidationError, "Value '%d' at 'limit' failed to satisfy "+
+					"constraint: Minimum value of 1. Maximum value of 100.", limit),
+			}
+		}
+	}
+
+	var keyArn string
+	if req.KeyId != nil {
+		var err error
+		keyArn, err = k.ResolveKeyArn(req.KeyId)
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		if _, err := k.Db.LoadKey(keyArn); err != nil {
+			if errors.Is(err, data.ErrKeyNotFound) {
+				return nil, []error{
+					kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyArn),
+				}
+			}
+			return nil, []error{err}
+		}
+	}
+
+	reqMarker := req.Marker
+	if reqMarker != nil {
+		var err error
+		reqMarker, err = DecodeMarker(reqMarker)
+		if err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	fetchLimit := int64(limit + 1)
+	marker := ""
+	if reqMarker != nil {
+		marker = *reqMarker
+	}
+
+	aliases, err := k.Db.ListAlias("", fetchLimit, marker, keyArn)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	truncated := false
+	var nextMarker *string
+
+	if int32(len(aliases)) > limit {
+		truncated = true
+		aliases = aliases[:limit]
+		lastAlias := aliases[len(aliases)-1]
+		if lastAlias.AliasArn != nil {
+			nextMarker = EncodeMarker("alias/" + *lastAlias.AliasArn)
+		}
+	}
+
+	outputAliases := make([]types.AliasListEntry, 0, len(aliases))
+	for _, alias := range aliases {
+		outputAliases = append(outputAliases, alias)
+	}
+
+	return &awskms.ListAliasesOutput{
+		Aliases:    outputAliases,
+		NextMarker: nextMarker,
+		Truncated:  truncated,
+	}, nil
 }

--- a/internal/kms/list_key_policies.go
+++ b/internal/kms/list_key_policies.go
@@ -2,11 +2,68 @@ package kms
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) ListKeyPolicies(ctx context.Context, req awskms.ListKeyPoliciesInput) (*awskms.ListKeyPoliciesOutput, []error) {
-	// TODO
-	return nil, nil
+	limit := int32(100)
+	if req.Limit != nil {
+		limit = *req.Limit
+
+		if limit < 1 || limit > 1000 {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseValidationError, "Value '%d' at 'limit' failed to satisfy "+
+					"constraint: Minimum value of 1. Maximum value of 1000.", limit),
+			}
+		}
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	_, err = k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	var marker *string
+	if req.Marker != nil {
+		marker, err = DecodeMarker(req.Marker)
+		if err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	if marker != nil && *marker != "default" {
+		return nil, []error{fmt.Errorf("%w: %s", data.ErrInvalidMarker, *marker)}
+	}
+
+	if marker != nil && *marker == "default" {
+		return &awskms.ListKeyPoliciesOutput{
+			PolicyNames: nil,
+			Truncated:   false,
+		}, nil
+	}
+
+	policies := []string{"default"}
+	if limit < 1 {
+		policies = nil
+	}
+
+	return &awskms.ListKeyPoliciesOutput{
+		PolicyNames: policies,
+		Truncated:   false,
+	}, nil
 }

--- a/internal/kms/list_resource_tags.go
+++ b/internal/kms/list_resource_tags.go
@@ -2,11 +2,84 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) ListResourceTags(ctx context.Context, req awskms.ListResourceTagsInput) (*awskms.ListResourceTagsOutput, []error) {
-	// TODO
-	return nil, nil
+	limit := int32(50)
+	if req.Limit != nil {
+		limit = *req.Limit
+
+		if limit < 1 || limit > 50 {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseValidationError, "Value '%d' at 'limit' failed to satisfy "+
+					"constraint: Minimum value of 1. Maximum value of 50.", limit),
+			}
+		}
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	reqMarker := req.Marker
+	if reqMarker != nil {
+		reqMarker, err = DecodeMarker(reqMarker)
+		if err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	fetchLimit := int64(limit + 1)
+	marker := ""
+	if reqMarker != nil {
+		marker = *reqMarker
+	}
+
+	tagEntries, err := k.Db.ListTags(key.GetArn(), fetchLimit, marker)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	truncated := false
+	var nextMarker *string
+
+	if int32(len(tagEntries)) > limit {
+		truncated = true
+		tagEntries = tagEntries[:limit]
+		lastTag := tagEntries[len(tagEntries)-1]
+		if lastTag.TagKey != nil {
+			nextMarker = EncodeMarker("tag/" + key.GetArn() + "/" + *lastTag.TagKey)
+		}
+	}
+
+	tags := make([]types.Tag, 0, len(tagEntries))
+	for _, tag := range tagEntries {
+		if tag == nil {
+			continue
+		}
+		tags = append(tags, *tag)
+	}
+
+	return &awskms.ListResourceTagsOutput{
+		NextMarker: nextMarker,
+		Tags:       tags,
+		Truncated:  truncated,
+	}, nil
 }

--- a/internal/kms/put_key_policy.go
+++ b/internal/kms/put_key_policy.go
@@ -2,11 +2,66 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
+	"github.com/nsmithuk/local-kms/internal/kms/validation"
 )
 
 func (k KmsService) PutKeyPolicy(ctx context.Context, req awskms.PutKeyPolicyInput) (*awskms.PutKeyPolicyOutput, []error) {
-	// TODO
-	return nil, nil
+	validator := validation.Validator{}
+	validationErrors := make([]error, 0)
+
+	if err := validator.RequiredPointer(req.Policy, "Policy"); err != nil {
+		validationErrors = append(validationErrors, err)
+	} else if err := validator.Length(req.Policy, "policy", 32768); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, validationErrors
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	policyName := "default"
+	if req.PolicyName != nil && *req.PolicyName != "" {
+		policyName = *req.PolicyName
+	}
+	if policyName != "default" {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseValidationError, "PolicyName must be default"),
+		}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	if err := setKeyPolicy(key, *req.Policy); err != nil {
+		return nil, []error{err}
+	}
+
+	if err := k.Db.SaveKey(key); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.PutKeyPolicyOutput{}, nil
 }

--- a/internal/kms/tag_resource.go
+++ b/internal/kms/tag_resource.go
@@ -2,11 +2,52 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
+	"github.com/nsmithuk/local-kms/internal/kms/validation"
 )
 
 func (k KmsService) TagResource(ctx context.Context, req awskms.TagResourceInput) (*awskms.TagResourceOutput, []error) {
-	// TODO
-	return nil, nil
+	validator := validation.Validator{}
+	validationErrors := make([]error, 0)
+
+	if errs := validator.Tags(req.Tags); len(errs) > 0 {
+		validationErrors = append(validationErrors, errs...)
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, validationErrors
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	for _, tag := range req.Tags {
+		if err := k.Db.SaveTag(key, tag); err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	return &awskms.TagResourceOutput{}, nil
 }

--- a/internal/kms/untag_resource.go
+++ b/internal/kms/untag_resource.go
@@ -2,11 +2,103 @@ package kms
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"slices"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
 )
 
 func (k KmsService) UntagResource(ctx context.Context, req awskms.UntagResourceInput) (*awskms.UntagResourceOutput, []error) {
-	// TODO
-	return nil, nil
+	if len(req.TagKeys) == 0 {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseValidationError, "'TagKeys' is a required field"),
+		}
+	}
+
+	for i, tagKey := range req.TagKeys {
+		if len(tagKey) < 1 {
+			return nil, []error{
+				kmserr.New(
+					kmserr.TypeValidation,
+					kmserr.CauseTagException,
+					fmt.Sprintf("Value '' at 'tags.%d.member.tagKey' failed to satisfy constraint: Member must have length greater than or equal to 1", i+1),
+				),
+			}
+		}
+
+		if len(tagKey) > 128 {
+			return nil, []error{
+				kmserr.New(
+					kmserr.TypeValidation,
+					kmserr.CauseTagException,
+					fmt.Sprintf("Value '%s' at 'tags.%d.member.tagKey' failed to satisfy constraint: Member must have length less than or equal to 128", tagKey, i+1),
+				),
+			}
+		}
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	remainingTags := make([]*types.Tag, 0)
+	marker := ""
+	for {
+		tags, err := k.Db.ListTags(key.GetArn(), 100, marker)
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		for _, tag := range tags {
+			if tag.TagKey != nil && !slices.Contains(req.TagKeys, *tag.TagKey) {
+				remainingTags = append(remainingTags, tag)
+			}
+		}
+
+		if len(tags) < 100 {
+			break
+		}
+
+		lastTag := tags[len(tags)-1]
+		if lastTag.TagKey == nil {
+			break
+		}
+		marker = "tag/" + key.GetArn() + "/" + *lastTag.TagKey
+	}
+
+	if err := k.Db.DeleteTag(key); err != nil {
+		return nil, []error{err}
+	}
+
+	for _, tag := range remainingTags {
+		if tag == nil {
+			continue
+		}
+		if err := k.Db.SaveTag(key, *tag); err != nil {
+			return nil, []error{err}
+		}
+	}
+
+	return &awskms.UntagResourceOutput{}, nil
 }

--- a/internal/kms/update_alias.go
+++ b/internal/kms/update_alias.go
@@ -2,11 +2,73 @@ package kms
 
 import (
 	"context"
+	"errors"
+	"strings"
+	"time"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
+	"github.com/nsmithuk/local-kms/internal/kms/validation"
 )
 
 func (k KmsService) UpdateAlias(ctx context.Context, req awskms.UpdateAliasInput) (*awskms.UpdateAliasOutput, []error) {
-	// TODO
-	return nil, nil
+	validator := validation.Validator{}
+	validationErrors := make([]error, 0)
+
+	if err := validator.AliasName(req.AliasName); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+	if err := validator.AliasKeyId(req.TargetKeyId); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+	if err := validator.Length(req.AliasName, "AliasName", 256); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, validationErrors
+	}
+
+	targetKeyArn, err := k.ResolveKeyArn(req.TargetKeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(targetKeyArn)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "Key %s not found.", targetKeyArn),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	aliasArn := k.ArnPrefix() + "alias/" + strings.TrimPrefix(*req.AliasName, "alias/")
+	alias, err := k.Db.LoadAlias(aliasArn)
+	if err != nil {
+		if errors.Is(err, data.ErrAliasNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "An alias with the name %s does not exists", *req.AliasName),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	now := time.Now()
+	alias.TargetKeyId = &targetKeyArn
+	alias.LastUpdatedDate = &now
+
+	if err := k.Db.SaveAlias(alias); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.UpdateAliasOutput{}, nil
 }

--- a/internal/kms/update_key_description.go
+++ b/internal/kms/update_key_description.go
@@ -2,11 +2,58 @@ package kms
 
 import (
 	"context"
+	"errors"
 
 	awskms "github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/nsmithuk/local-kms/internal/kms/data"
+	"github.com/nsmithuk/local-kms/internal/kms/kmserr"
+	"github.com/nsmithuk/local-kms/internal/kms/validation"
 )
 
 func (k KmsService) UpdateKeyDescription(ctx context.Context, req awskms.UpdateKeyDescriptionInput) (*awskms.UpdateKeyDescriptionOutput, []error) {
-	// TODO
-	return nil, nil
+	validator := validation.Validator{}
+	validationErrors := make([]error, 0)
+
+	if err := validator.Length(req.Description, "description", 8192); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, validationErrors
+	}
+
+	keyId, err := k.ResolveKeyArn(req.KeyId)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	key, err := k.Db.LoadKey(keyId)
+	if err != nil {
+		if errors.Is(err, data.ErrKeyNotFound) {
+			return nil, []error{
+				kmserr.NewValidation(kmserr.CauseNotFoundException, "A key with the arn %s does not exists", keyId),
+			}
+		}
+		return nil, []error{err}
+	}
+
+	if key.IsPendingDeletion() {
+		return nil, []error{
+			kmserr.NewValidation(kmserr.CauseKMSInvalidStateException, "%s is pending deletion.", key.GetArn()),
+		}
+	}
+
+	description := req.Description
+	if description == nil {
+		empty := ""
+		description = &empty
+	}
+
+	key.GetMetadata().Description = description
+
+	if err := k.Db.SaveKey(key); err != nil {
+		return nil, []error{err}
+	}
+
+	return &awskms.UpdateKeyDescriptionOutput{}, nil
 }


### PR DESCRIPTION
### Motivation
- Complete previously unimplemented `internal/kms` TODOs to provide working KMS operations for key lifecycle, rotation, policies, aliases and tags so the service can be used end-to-end.

### Description
- Implemented key state management APIs: `EnableKey`, `DisableKey`, and `CancelKeyDeletion`, which update `KeyMetadata`, validate states and persist changes via the DB, returning `kmserr`-formatted validation errors when appropriate.
- Implemented key rotation APIs: `EnableKeyRotation`, `DisableKeyRotation`, and `GetKeyRotationStatus` with symmetric-key checks, `RotationPeriodInDays` handling, and persistence of rotation scheduling to the key record.
- Added policy helpers `getKeyPolicy`/`setKeyPolicy` and implemented `GetKeyPolicy`, `PutKeyPolicy`, and `ListKeyPolicies` with `PolicyName` validation, length checks and DB-backed storage.
- Implemented alias and tag operations including `ListAliases`, `UpdateAlias`, `TagResource`, `UntagResource`, and `ListResourceTags` with pagination via `EncodeMarker`/`DecodeMarker`, input validation, and DB interactions for listing, saving and deleting tags and aliases.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697111e6883c832e9e920fad04a424e4)